### PR TITLE
Fixes "Finish" button that takes user back to first question of quiz

### DIFF
--- a/ThunderCloud/TSCQuizCompletionViewController.m
+++ b/ThunderCloud/TSCQuizCompletionViewController.m
@@ -52,8 +52,6 @@
             self.navigationItem.leftBarButtonItem = [TSCSplitViewController sharedController].menuButton;
         }
         
-        self.navigationItem.rightBarButtonItem = [self rightBarButtonItem];
-        
         if ([self quizIsCorrect]) {
             
             self.navigationItem.leftBarButtonItems = [self additionalLeftBarButtonItems];
@@ -83,7 +81,7 @@
 
 -(UIBarButtonItem *)rightBarButtonItem
 {
-    if ([[[[UIApplication sharedApplication] keyWindow] rootViewController] isKindOfClass:[TSCSplitViewController class]] && !self.presentingViewController) {
+    if ([[[[UIApplication sharedApplication] keyWindow] rootViewController] isKindOfClass:[TSCSplitViewController class]] && !self.presentingViewController && self.navigationController.viewControllers.count == self.quizPage.questions.count + 1) {
         return nil;
     }
     UIBarButtonItem *finishButton = [[UIBarButtonItem alloc] initWithTitle:[NSString stringWithLocalisationKey:@"_QUIZ_BUTTON_FINISH" fallbackString:@"Finish"] style:UIBarButtonItemStylePlain target:self action:@selector(finishQuiz:)];
@@ -123,6 +121,8 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    
+    self.navigationItem.rightBarButtonItem = [self rightBarButtonItem];
     
     BOOL linkRowsContainTableRows = NO;
     

--- a/ThunderCloud/TSCQuizCompletionViewController.m
+++ b/ThunderCloud/TSCQuizCompletionViewController.m
@@ -83,6 +83,9 @@
 
 -(UIBarButtonItem *)rightBarButtonItem
 {
+    if ([[[[UIApplication sharedApplication] keyWindow] rootViewController] isKindOfClass:[TSCSplitViewController class]] && !self.presentingViewController) {
+        return nil;
+    }
     UIBarButtonItem *finishButton = [[UIBarButtonItem alloc] initWithTitle:[NSString stringWithLocalisationKey:@"_QUIZ_BUTTON_FINISH" fallbackString:@"Finish"] style:UIBarButtonItemStylePlain target:self action:@selector(finishQuiz:)];
     return finishButton;
 }


### PR DESCRIPTION
On iPad users were been taken back to the first quiz question when pressing finish.

Somewhere this finish button has been allowed back in on iPad where it was previously removed. I have now conditionally removed it based on whether the quiz completion page is being shown on iPad and is not currently presented.