### PR TITLE
Delta bundles are now downloaded by ThunderRequest

### DIFF
--- a/ThunderCloud/TSCContentController.h
+++ b/ThunderCloud/TSCContentController.h
@@ -78,7 +78,7 @@ typedef NS_ENUM(NSInteger, TSCContentUpdate) {
 /**
  A request controller responsible for handling file downloads. It does not have a base URL set
 */
-@property (nonnull, strong, nonnull) TSCRequestController *downloadRequestController;
+@property (nonatomic, strong) TSCRequestController *downloadRequestController;
 
 /**
  @abstract The shared language controller used to access localisations throughout the app

--- a/ThunderCloud/TSCContentController.h
+++ b/ThunderCloud/TSCContentController.h
@@ -76,6 +76,11 @@ typedef NS_ENUM(NSInteger, TSCContentUpdate) {
 @property (nonatomic, strong) TSCRequestController *requestController;
 
 /**
+ A request controller responsible for handling file downloads. It does not have a base URL set
+*/
+@property (nonnull, strong, nonnull) TSCRequestController *downloadRequestController;
+
+/**
  @abstract The shared language controller used to access localisations throughout the app
  */
 @property (nonatomic, strong) TSCStormLanguageController *languageController;


### PR DESCRIPTION
Requests were being handled by a standalone download manager but I have now moved it to use it's own ThunderRequest instance.

This means that the new loading indicator stuff will work with this too. Should give people a better idea of when delta bundles are downloading and when they are done/failed.

Especially good for clients/users with slow internet connections. 

This also works when switching to the developer bundle.