### PR TITLE
Adds 'UriLink' to list of linkClass which prevents link returning nil

### DIFF
--- a/ThunderCloud/TSCLink.m
+++ b/ThunderCloud/TSCLink.m
@@ -60,7 +60,7 @@
                 self.url = [NSURL URLWithString:cleanString];
             }
             
-            if (self.url || [self.linkClass isEqualToString:@"SmsLink"] || [self.linkClass isEqualToString:@"EmergencyLink"] || [self.linkClass isEqualToString:@"ShareLink"] || [self.linkClass isEqualToString:@"TimerLink"] || [self.linkClass isEqualToString:@"ExternalLink"]) {
+            if (self.url || [self.linkClass isEqualToString:@"SmsLink"] || [self.linkClass isEqualToString:@"EmergencyLink"] || [self.linkClass isEqualToString:@"ShareLink"] || [self.linkClass isEqualToString:@"TimerLink"] || [self.linkClass isEqualToString:@"ExternalLink"] || [self.linkClass isEqualToString:@"UriLink"]) {
                 
                 return self;
                 


### PR DESCRIPTION
Fixes a problem where a link class was defined as 'UriLink' but this was not defined in the TSCLink initialiser which meant it was returning nil