### PR TITLE
Native Vectors

### DIFF
--- a/ThunderCloud/TSCStormObject.m
+++ b/ThunderCloud/TSCStormObject.m
@@ -72,7 +72,6 @@ static TSCStormObject *sharedController = nil;
         if (viewController) {
             return viewController;
         }
-        
         return nil;
     }
     

--- a/ThunderCloud/TSCStormObject.m
+++ b/ThunderCloud/TSCStormObject.m
@@ -7,6 +7,7 @@
 //
 
 #import "TSCStormObject.h"
+#import "TSCStormViewController.h"
 #import <objc/runtime.h>
 
 @implementation TSCStormObject
@@ -62,6 +63,18 @@ static TSCStormObject *sharedController = nil;
 {
     // Generate default class name
     NSString *className = [NSString stringWithFormat:@"TSC%@", dictionary[@"class"]];
+    
+    //Double check for native pages (This is for when the root page (vector) is native)
+    if ([className isEqualToString:@"TSCNativePage"] && dictionary[@"name"] && [dictionary[@"name"] isKindOfClass:[NSString class]]) {
+        
+        id viewController = [TSCStormViewController viewControllerForNativePageName:dictionary[@"name"]];
+        
+        if (viewController) {
+            return viewController;
+        }
+        
+        return nil;
+    }
     
     // Select a class
     Class class = [TSCStormObject classFromClassName:className parentObject:parentObject];


### PR DESCRIPTION
Storm has support for native pages and until now we have never attempted to have the vector of the app to be a native page. This pull request fixes the app not loading correctly by checking for a native page identifier then loading that page instead.

I've identified this as a bug with Steve but for now, we can roll this out to catch it until all CMS are updated to accommodate. 