### PR TITLE
Adds named page property to list page

### DIFF
--- a/ThunderCloud/TSCListPage.h
+++ b/ThunderCloud/TSCListPage.h
@@ -37,6 +37,11 @@
 @property (nonatomic, copy) NSString *pageId;
 
 /**
+ @abstract The internal name for this page. Named pages can be used for native overrides and for identifying pages that may change with delta publishes. By default pages do not have names but they can be added in the CMS
+ */
+@property (nullable, nonatomic, copy) NSString *pageName;
+
+/**
  Initalizes the page with the contents of a file path
  @param filePath The system file path of which to extract the contents
  @discussion The contents of the file path has to be a json representation of a `TSCListPage` for the page to render correctly

--- a/ThunderCloud/TSCListPage.m
+++ b/ThunderCloud/TSCListPage.m
@@ -38,6 +38,10 @@
         self.parentObject = parentObject;
         self.title = TSCLanguageString(dictionary[@"title"][@"content"]);
         
+        if ([dictionary isKindOfClass:[NSDictionary class]] && dictionary[@"name"] && [dictionary[@"name"] isKindOfClass:[NSString class]]) {
+            self.pageName = dictionary[@"name"];
+        }
+        
         if ([dictionary[@"id"] isKindOfClass:[NSNumber class]]) {
             self.pageId = [NSString stringWithFormat:@"%@",dictionary[@"id"]];
         } else {


### PR DESCRIPTION
Some pages can be named in Storm to make them easier to find and also so that they can still be located if the client deletes them and creates a new page with the same name.

This is useful when doing list page overrides.

Let me know if you're happy with it then I'll merge :)