### PR TITLE
Adds support to TSCStormViewController for registering a custom block

### DIFF
--- a/ThunderCloud/TSCStormViewController.h
+++ b/ThunderCloud/TSCStormViewController.h
@@ -9,6 +9,15 @@
 @import UIKit;
 
 /**
+ A block which is called when a native link is clicked in the App
+
+ @param name The native link name
+ @param navigationController The view navigation controller which the link was pushed on
+ @return A boolean as to whether the block has handled the link or not
+ */
+typedef BOOL (^TSCNativeLinkHandler)(NSString * _Nonnull name, UINavigationController * _Nonnull navigationController);
+
+/**
  `TSCStormViewController` can be given a cache URL, in the context of Storm that references a storm page. This class will read out the data at the given file path and run it through storm generation.
  
  This is particularly useful if you want to push to a Storm page from your native pages at any point in the app
@@ -18,7 +27,6 @@
 ///---------------------------------------------------------------------------------------
 /// @name Initializing a TSCStormViewController
 ///---------------------------------------------------------------------------------------
-@property (nonatomic, strong) NSMutableDictionary *nativePageLookupDictionary;
 
 /**
  Initializes a TSCStormViewController
@@ -51,6 +59,17 @@
  @abstract The shared instance of a storm view used to register overrides
  */
 + (TSCStormViewController *)sharedController;
+
+/**
+ A map from native page name to the class or storyboard dictionary it represents
+ */
+@property (nonatomic, strong) NSMutableDictionary *nativePageLookupDictionary;
+
+/**
+ A block which can be registered to handle storm native links
+ @discussion This can be used for example to catch links with specific names and show custom UI or perform custom actions
+ */
+@property (nonatomic, strong) TSCNativeLinkHandler nativeLinkHandler;
 
 /**
  @abstract To ensure that storm pushes to the native page that you have configured in the CMS. Register it using this method before creating the `TSCAppViewController`

--- a/ThunderCloud/UINavigationController+TSCNavigationController.m
+++ b/ThunderCloud/UINavigationController+TSCNavigationController.m
@@ -141,17 +141,26 @@ static NSString *disclaimerPageId = nil;
         nativePageLookupDictionary = [NSMutableDictionary dictionary];
     }
     
-    for (NSString *key in [[TSCStormViewController sharedController] nativePageLookupDictionary].allKeys) {
-        nativePageLookupDictionary[key] = [[TSCStormViewController sharedController] nativePageLookupDictionary][key];
-    }
-    
-    for (id key in nativePageLookupDictionary) {
-        if ([key isEqualToString:link.destination]) {
-            if ([nativePageLookupDictionary[key] isKindOfClass:[NSDictionary class]]) {
-                [self TSC_handleNativeLinkWithStoryboardDictionary:nativePageLookupDictionary[key]];
+    if ([link.linkClass isEqualToString:@"NativeLink"]) {
+        
+        // If we have a nativeLinkHandler block and it handles this link, then don't continue
+        if ([TSCStormViewController sharedController].nativeLinkHandler && [TSCStormViewController sharedController].nativeLinkHandler(link.destination, self)) {
+            return;
+        }
+        
+        for (NSString *key in [[TSCStormViewController sharedController] nativePageLookupDictionary].allKeys) {
+            nativePageLookupDictionary[key] = [[TSCStormViewController sharedController] nativePageLookupDictionary][key];
+        }
+        
+        for (id key in nativePageLookupDictionary) {
+            
+            if ([key isEqualToString:link.destination]) {
                 
-            } else if ([nativePageLookupDictionary[key] isKindOfClass:[NSString class]]) {
-                [self TSC_handleNativeLinkWithClassName:nativePageLookupDictionary[key]];
+                if ([nativePageLookupDictionary[key] isKindOfClass:[NSDictionary class]]) {
+                    [self TSC_handleNativeLinkWithStoryboardDictionary:nativePageLookupDictionary[key]];
+                } else if ([nativePageLookupDictionary[key] isKindOfClass:[NSString class]]) {
+                    [self TSC_handleNativeLinkWithClassName:nativePageLookupDictionary[key]];
+                }
             }
         }
     }

--- a/ThunderCloud/UINavigationController+TSCNavigationController.m
+++ b/ThunderCloud/UINavigationController+TSCNavigationController.m
@@ -219,7 +219,7 @@ static NSString *disclaimerPageId = nil;
         if ([newViewController isKindOfClass:[UINavigationController class]]) {
             [self presentViewController:(UINavigationController *)newViewController animated:true completion:nil];
         } else {
-            [self.navigationController pushViewController:newViewController animated:true];
+            [self pushViewController:newViewController animated:true];
         }
     }
 }


### PR DESCRIPTION
Adds support for registering a custom block which can perform any action when a native link is clicked in CMS content. 