### PR TITLE
Changes files:inDictionary on ContentController to only return unique fileNames

### DIFF
--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -1049,17 +1049,17 @@ public extension ContentController {
     ///
     /// - parameter inDirectory: The directory to look for files in
     ///
-    /// - returns: An array of file names
-    public func files(inDirectory: String) -> [String]? {
+    /// - returns: A set of file names
+    public func files(inDirectory: String) -> Set<String>? {
         
-        var files: [String] = []
+        var files: Set<String> = []
         
         if let bundleDirectory = bundleDirectory {
             
             let filePath = bundleDirectory.appending("/\(inDirectory)")
             do {
                 let contents = try FileManager.default.contentsOfDirectory(atPath: filePath)
-                files.append(contentsOf: contents)
+                contents.forEach({ files.insert($0) })
             } catch let error {
                 print("error getting files in bundle directory: \(error.localizedDescription)")
             }
@@ -1070,7 +1070,7 @@ public extension ContentController {
             let filePathURL = deltaDirectory.appendingPathComponent(inDirectory)
             do {
                 let contents = try FileManager.default.contentsOfDirectory(atPath: filePathURL.path)
-                files.append(contentsOf: contents)
+                contents.forEach({ files.insert($0) })
             } catch let error {
                 print("error getting files in cache directory: \(error.localizedDescription)")
             }

--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -1045,25 +1045,14 @@ public extension ContentController {
         return self.fileUrl(forResource: fileName, withExtension: pathExtension, inDirectory: forCacheURL.host)
     }
     
-    /// Returns all the storm files available in a specific directory of the bundle
+    /// Returns all the storm fileNames available in a specific directory of the bundle and delta
     ///
     /// - parameter inDirectory: The directory to look for files in
     ///
-    /// - returns: A set of file names
-    public func files(inDirectory: String) -> Set<String>? {
+    /// - returns: A set of file names found in a directory (note: this does NOT include the path)
+    public func fileNames(inDirectory: String) -> Set<String>? {
         
         var files: Set<String> = []
-        
-        if let bundleDirectory = bundleDirectory {
-            
-            let filePath = bundleDirectory.appending("/\(inDirectory)")
-            do {
-                let contents = try FileManager.default.contentsOfDirectory(atPath: filePath)
-                contents.forEach({ files.insert($0) })
-            } catch let error {
-                print("error getting files in bundle directory: \(error.localizedDescription)")
-            }
-        }
         
         if let deltaDirectory = deltaDirectory {
             
@@ -1073,6 +1062,17 @@ public extension ContentController {
                 contents.forEach({ files.insert($0) })
             } catch let error {
                 print("error getting files in cache directory: \(error.localizedDescription)")
+            }
+        }
+        
+        if let bundleDirectory = bundleDirectory {
+            
+            let filePath = bundleDirectory.appending("/\(inDirectory)")
+            do {
+                let contents = try FileManager.default.contentsOfDirectory(atPath: filePath)
+                contents.forEach({ files.insert($0) })
+            } catch let error {
+                print("error getting files in bundle directory: \(error.localizedDescription)")
             }
         }
         
@@ -1225,7 +1225,7 @@ public extension ContentController {
     
     private func indexNewContent(with completion: @escaping CoreSpotlightCompletion) {
         
-        guard let pages = files(inDirectory: "pages") else {
+        guard let pages = fileNames(inDirectory: "pages") else {
             
             completion(ContentControllerError.noFilesInBundle)
             return


### PR DESCRIPTION
The current implementation of the method checks the bundle and delta update folder for files, however if the file exists in both directories, the filename will appear twice in the array which I don't think is something you would ever want. Let me know :) 