### PR TITLE
Checks for direct linkClass when handling page

### DIFF
--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -38,7 +38,7 @@ public extension UINavigationController {
 			
 			handleITunes(url: url)
 			
-		} else if pathExtension == "json" || scheme == "app" && link.linkClass != .native {
+		} else if (pathExtension == "json" || scheme == "app") && link.linkClass == .internal {
 			
 			handlePage(link: link)
 			


### PR DESCRIPTION
Before swift re-write this method didn't use `else if` so the later statement checking `if link.linkClass == .app` would still be run and the app switch dialogue shown. However now that I've changed it to `if else` this check needs to be more stringent... The only linkClass that should be handled as pushing a cached json file is `internal`