### PR TITLE
Preventing reset of majorLanguagePack

### DIFF
--- a/ThunderCloud/StormLanguageController.swift
+++ b/ThunderCloud/StormLanguageController.swift
@@ -194,7 +194,7 @@ public class StormLanguageController: NSObject {
                     regionalLanguagePack = pack
                     
                     //Set the major language if it matches
-                    if let languageCode = pack.fileName.components(separatedBy: "_").last {
+                    if let languageCode = pack.fileName.components(separatedBy: "_").last, majorLanguagePack == nil {
                         let languageOnlyLocale = Locale(identifier: languageCode)
                         majorLanguagePack = LanguagePack(locale: languageOnlyLocale, fileName: languageCode)
                     }
@@ -208,6 +208,7 @@ public class StormLanguageController: NSObject {
                     //Set the major language if only the language matches. Major language pack always exists if a minor one exists
                     if let languageCode = pack.locale.languageCode, let languageName = pack.fileName.components(separatedBy: "_").first {
                         majorLanguagePack = LanguagePack(locale: Locale(identifier: languageCode), fileName: languageName)
+                        return (regionalLanguagePack: nil, majorLanguagePack: majorLanguagePack)
                     }
                 }
             }


### PR DESCRIPTION
If the `majorLanguagePack` property has been set already (such as the first preferred language is one specified by the user with the `overrideLanguagePack` property), ensure that it is not overridden when further language packs and locales are compared. This should fix an issue, where the user-preferred language was selected, but then was overridden at a later point with the device specific language.