### PR TITLE
Changing how overridden languages are used.

### DIFF
--- a/ThunderCloud/StormLanguageController.swift
+++ b/ThunderCloud/StormLanguageController.swift
@@ -240,17 +240,20 @@ public class StormLanguageController: NSObject {
         // If we have an override set to use, lets try to use that instead of detecting language packs here.
         // If we can't use it, then we'll fallback to use normal detection.
         if let overrideLanguagePack = overrideLanguagePack {
-            let overrideFileName = overrideLanguagePack.fileName
+            let fileName = overrideLanguagePack.fileName
             
-            currentLanguage = overrideFileName
+            currentLanguage = fileName
             
             // Handle the major language element of this language (i.e., eng from usa_eng). If there is no region specified, this will just return the language.
-            if let majorLanguage = overrideFileName.components(separatedBy: "_").last, let majorPackPath = ContentController.shared.fileUrl(forResource: majorLanguage, withExtension: "json", inDirectory: "languages") {
+            if let majorLanguage = fileName.components(separatedBy: "_").last,
+                let majorPackPath = ContentController.shared.fileUrl(forResource: majorLanguage, withExtension: "json", inDirectory: "languages") {
                 writeLanguageData(from: majorPackPath.path, into: &finalLanguage)
                 
-                // Now attempt to handle the regional version of the language (i.e., usa_eng). If there was no region specified and we've already handled this above, we skip this as it's unnecessary.
-                if let regionalLanguagePath = ContentController.shared.fileUrl(forResource: overrideFileName, withExtension: "json", inDirectory: "languages"), majorLanguage != overrideFileName {
-                    writeLanguageData(from: regionalLanguagePath.path, into: &finalLanguage)
+                // Now attempt to handle the regional version of the language (i.e., usa_eng).
+                // If there was no region specified and we've already handled this above, we skip this as it's unnecessary.
+                if let regionalPath = ContentController.shared.fileUrl(forResource: fileName, withExtension: "json", inDirectory: "languages"),
+                    majorLanguage != fileName {
+                    writeLanguageData(from: regionalPath.path, into: &finalLanguage)
                 }
                 
                 // If we've got here, loading the override language was successful, and we should leave now.

--- a/ThunderCloud/StormLanguageController.swift
+++ b/ThunderCloud/StormLanguageController.swift
@@ -194,7 +194,7 @@ public class StormLanguageController: NSObject {
                     regionalLanguagePack = pack
                     
                     //Set the major language if it matches
-                    if let languageCode = pack.fileName.components(separatedBy: "_").last, majorLanguagePack == nil {
+                    if let languageCode = pack.fileName.components(separatedBy: "_").last {
                         let languageOnlyLocale = Locale(identifier: languageCode)
                         majorLanguagePack = LanguagePack(locale: languageOnlyLocale, fileName: languageCode)
                     }
@@ -208,7 +208,6 @@ public class StormLanguageController: NSObject {
                     //Set the major language if only the language matches. Major language pack always exists if a minor one exists
                     if let languageCode = pack.locale.languageCode, let languageName = pack.fileName.components(separatedBy: "_").first {
                         majorLanguagePack = LanguagePack(locale: Locale(identifier: languageCode), fileName: languageName)
-                        return (regionalLanguagePack: nil, majorLanguagePack: majorLanguagePack)
                     }
                 }
             }


### PR DESCRIPTION
Previously, the flow for using overridden languages was baked into the same code that handled detecting the device's language. This was affecting how overridden languages were being used - in some cases it would ignore the overridden language in preference of another. A previous fix resolved that issue, but also impacted upon how the device's regional version of a language was picked up. This merge request aims to solve both issues - resolving how overridden languages are used by moving the flow out of the standard detection flow, and fixing how the language detection works too.

I've also added further documentation to the codebase to clarify the purpose of some parts, and shifted some reusable code out into smaller functions.

Any questions, let me know!