### PR TITLE
Sends `deviceId` to server when registering for push

### DIFF
--- a/ThunderCloud/StormNotificationHelper.swift
+++ b/ThunderCloud/StormNotificationHelper.swift
@@ -33,6 +33,10 @@ public class StormNotificationHelper {
 			body["appId"] = appId
 		}
 		
+		if let _deviceId = UIDevice.current.identifierForVendor?.uuidString {
+			body["deviceId"] = _deviceId
+		}
+		
 		// If we're geotargeted, then let's resend the push token every time
 		let tokenHasChanged = defaults.string(forKey: "TSCPushToken") != token
 		guard tokenHasChanged || geoTargeted else { return }


### PR DESCRIPTION
Fixes a critical issue where ThunderCloud did not send `deviceId` as part of the payload when registering for push tokens. Unfortunately the server returns `202 Accepted` so this issue was not noticed sooner.