### PR TITLE
Makes sure `ListItem` correctly hides/un-hides text labels upon confi…

### DIFF
--- a/ThunderCloud/ButtonListItem.swift
+++ b/ThunderCloud/ButtonListItem.swift
@@ -76,10 +76,7 @@ open class ButtonListItem: EmbeddedLinksListItem {
 		guard let links = embeddedCell.links, links.count == 1 else {
 			return
 		}
-		
-		embeddedCell.cellTextLabel?.isHidden = title == nil
-		embeddedCell.cellDetailLabel?.isHidden = subtitle == nil
-		
+	
 		embeddedCell.contentStackView?.isHidden = title == nil && subtitle == nil && image == nil && imageURL == nil
 		
 		embeddedCell._target = target

--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -58,10 +58,6 @@ open class ListItem: StormObject, Row {
 		if let linkDicationary = dictionary["link"] as? [AnyHashable : Any] {
 			link = StormLink(dictionary: linkDicationary)
 		}
-        
-        if title == "Timeframe to Appeal", let _subtitle = subtitle {
-            subtitle = _subtitle + _subtitle
-        }
 	}
 	
 	open func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {

--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -58,6 +58,10 @@ open class ListItem: StormObject, Row {
 		if let linkDicationary = dictionary["link"] as? [AnyHashable : Any] {
 			link = StormLink(dictionary: linkDicationary)
 		}
+        
+        if title == "Timeframe to Appeal", let _subtitle = subtitle {
+            subtitle = _subtitle + _subtitle
+        }
 	}
 	
 	open func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
@@ -87,6 +91,10 @@ open class ListItem: StormObject, Row {
 		
 		
 		if let tableCell = cell as? TableViewCell {
+            
+            tableCell.cellTextLabel?.isHidden = title == nil || title!.isEmpty
+            tableCell.cellDetailLabel?.isHidden = subtitle == nil || subtitle!.isEmpty
+            
 			tableCell.cellImageView?.isHidden = image == nil && imageURL == nil
 			tableCell.cellTextLabel?.font = ThemeManager.shared.theme.cellTitleFont
 			tableCell.cellDetailLabel?.font = ThemeManager.shared.theme.cellDetailFont


### PR DESCRIPTION
This fixes an issue where if a `ButtonListItem` was shown on certain size device on the same page as a `DescriptionListItem` the subtitle label would be hidden due to re-use issue in showing/hiding the labels. Showing and hiding of labels is now handled entirely by `ListItem`.