### PR TITLE
Fix/retain cycles

### DIFF
--- a/ThunderCloud/CollectionCell.swift
+++ b/ThunderCloud/CollectionCell.swift
@@ -22,9 +22,6 @@ open class CollectionCell: StormTableViewCell {
 	/// The `UICollectionViewFlowLayout` of the cells collection view
 	open var collectionViewLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
 	
-	/// The containing navigation controller of the cell
-	open var parentNavigationController: UINavigationController?
-	
 	fileprivate var currentPage: Int = 0 {
 		didSet {
 			pageControl.currentPage = currentPage

--- a/ThunderCloud/CollectionListItem.swift
+++ b/ThunderCloud/CollectionListItem.swift
@@ -148,22 +148,18 @@ open class CollectionListItem: ListItem {
 			guard let quizBadgeScrollerCell = cell as? QuizBadgeScrollerViewCell else { return }
 			quizBadgeScrollerCell.quizzes = quizzes
 			quizBadgeScrollerCell.badges = badges
-			parentNavigationController = quizBadgeScrollerCell.parentNavigationController
 		break
 		case .app:
 			guard let appCollectionCell = cell as? AppCollectionCell else { return }
 			appCollectionCell.apps = apps
-			parentNavigationController = appCollectionCell.parentNavigationController
 		break
 		case .link:
 			guard let linkCollectionCell = cell as? LinkCollectionCell else { return }
 			linkCollectionCell.links = links
-			parentNavigationController = linkCollectionCell.parentNavigationController
 		break
 		case .badge:
 			guard let badgeScrollerCell = cell as? BadgeScrollerViewCell else { return }
 			badgeScrollerCell.badges = badges
-			parentNavigationController = badgeScrollerCell.parentNavigationController
 		default: break
 		}
 	}

--- a/ThunderCloud/CollectionListItem.swift
+++ b/ThunderCloud/CollectionListItem.swift
@@ -48,6 +48,7 @@ open class CollectionListItem: ListItem {
 		if let quizCompletionObserver = quizCompletetionObserver {
 			NotificationCenter.default.removeObserver(quizCompletionObserver)
 		}
+        quizCompletetionObserver = nil
 	}
 	
 	public required init(dictionary: [AnyHashable : Any]) {

--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -39,7 +39,7 @@ open class ListItem: StormObject, Row {
 	open var detailTextColor: UIColor?
 	
 	/// The `UINavigationController` of the view controller the row is displayed in
-	var parentNavigationController: UINavigationController?
+	weak var parentNavigationController: UINavigationController?
 	
 	required public init(dictionary: [AnyHashable : Any]) {
 		

--- a/ThunderCloud/SpotlightListItem.swift
+++ b/ThunderCloud/SpotlightListItem.swift
@@ -49,7 +49,6 @@ open class SpotlightListItem: ListItem {
 		
 		guard let spotlightCell = cell as? SpotlightListItemCell else { return }
 		
-		super.configure(cell: cell, at: indexPath, in: tableViewController)
 		spotlightCell.spotlights = spotlights
 		spotlightCell.delegate = self
 	}

--- a/ThunderCloud/SpotlightListItemCell.swift
+++ b/ThunderCloud/SpotlightListItemCell.swift
@@ -18,7 +18,7 @@ public class SpotlightImageCollectionViewCell: UICollectionViewCell {
 	@IBOutlet public weak var textShadowImageView: UIImageView!
 }
 
-public protocol SpotlightListItemCellDelegate {
+public protocol SpotlightListItemCellDelegate: class {
 	func spotlightCell(cell: SpotlightListItemCell, didReceiveTapOnItem atIndex: Int)
 }
 
@@ -28,7 +28,7 @@ open class SpotlightListItemCell: StormTableViewCell {
 	
 	@IBOutlet private weak var pageIndicator: UIPageControl!
 	
-	var delegate: SpotlightListItemCellDelegate?
+	weak var delegate: SpotlightListItemCellDelegate?
 	
 	var currentPage: Int = 0 {
 		didSet {

--- a/ThunderCloud/StormTableViewCell.swift
+++ b/ThunderCloud/StormTableViewCell.swift
@@ -12,5 +12,5 @@ import ThunderTable
 open class StormTableViewCell: TableViewCell {
 	
 	/// The cells parent view controller (Set in configureCell func within ListItem)
-	var parentViewController: TableViewController?
+	weak var parentViewController: TableViewController?
 }


### PR DESCRIPTION
Whilst fixing a bug in a storm app I realised we have a fair few retain cycles being caused by various pieces of code. This fixes them by making circular references weak.