### PR TITLE
Publicises badgeId on `QuizGridItem`

### DIFF
--- a/ThunderCloud/QuizGridItem.swift
+++ b/ThunderCloud/QuizGridItem.swift
@@ -12,7 +12,7 @@ import ThunderCollection
 /// Used to display a quiz badge in a collection view
 open class QuizGridItem: GridItem {
 	
-	private var badgeId: String?
+	public var badgeId: String?
 
 	public required init?(dictionary: [AnyHashable : Any]) {
 		


### PR DESCRIPTION
Fairly self-explanatory. Was needed for a storm override in Blood.