### PR TITLE
Timestamp logging

### DIFF
--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -328,7 +328,7 @@ public class ContentController: NSObject {
     public func checkForUpdates(withTimestamp: TimeInterval, progressHandler: ContentUpdateProgressHandler? = nil) {
         
         checkingForUpdates = true
-        os_log("Checking for updates with timestamp: %t", log: contentControllerLog, type: .debug, withTimestamp)
+        os_log("Checking for updates with timestamp: %.0f", log: contentControllerLog, type: .debug, withTimestamp)
         
         var environment = "live"
         if DeveloperModeController.appIsInDevMode {


### PR DESCRIPTION
Fixes bug where timestamp would not be logged due to incorrect placeholder type.

Prevents a crash and now logs as a timestamp without the ".0" on the end.