### PR TITLE
Fixes "Segmentation Fault 11" when compiling for release

### DIFF
--- a/ThunderCloud/NavigationController.swift
+++ b/ThunderCloud/NavigationController.swift
@@ -13,15 +13,34 @@ import StoreKit
 import ThunderTable
 
 /// Any `UIViewController` can comply to this delegate. The extension provided in this file uses this method to style the navigation bar
-@objc public protocol NavigationBarDataSource {
+public protocol NavigationBarDataSource {
 	
-	@objc optional var navigationBarBackgroundImage: UIImage? { get }
+	var navigationBarBackgroundImage: UIImage? { get }
 	
-	@objc optional var navigationBarShadowImage: UIImage? { get }
+	var navigationBarShadowImage: UIImage? { get }
 	
-	@objc optional var navigationBarIsTranslucent: Bool { get }
+	var navigationBarIsTranslucent: Bool { get }
 	
-	@objc optional var navigationBarAlpha: CGFloat { get }
+	var navigationBarAlpha: CGFloat { get }
+}
+
+extension NavigationBarDataSource {
+    
+    var navigationBarBackgroundImage: UIImage? {
+        return nil
+    }
+    
+    var navigationBarShadowImage: UIImage? {
+        return nil
+    }
+    
+    var navigationBarIsTranslucent: Bool? {
+        return nil
+    }
+    
+    var navigationBarAlpha: CGFloat? {
+        return nil
+    }
 }
 
 public extension UINavigationController {


### PR DESCRIPTION
The optional protocol with optional type was causing a double optional. Attempting to nil-coalesce the double optional causes a segmentation fault.

As we no longer support objective-c in this branch of the framework I have updated it to be a Swift protocol with a default implementation.