### PR TITLE
Developer Mode Crash

### DIFF
--- a/ThunderCloud/StormLoginViewController.swift
+++ b/ThunderCloud/StormLoginViewController.swift
@@ -162,7 +162,7 @@ class StormLoginViewController: UIViewController {
 		childView.translatesAutoresizingMaskIntoConstraints = false
 		
 		// Constrain the success view controller to our container view
-		containerView.attachEdges(to: childView)
+		childView.attachEdges(to: containerView)
 		
 		UIView.animate(withDuration: 1.0, delay: 0.0, usingSpringWithDamping: 1.0, initialSpringVelocity: 0.0, options: [], animations: {
 			

--- a/ThunderCloud/StormLoginViewController.swift
+++ b/ThunderCloud/StormLoginViewController.swift
@@ -158,9 +158,6 @@ class StormLoginViewController: UIViewController {
 			backgroundView.removeGestureRecognizer(gestureRecognizer)
 		}
 		
-		// Remove translatesAutoresizingMaskIntoConstraints so we can constrain it to our container view
-		childView.translatesAutoresizingMaskIntoConstraints = false
-		
 		// Constrain the success view controller to our container view
 		childView.attachEdges(to: containerView)
 		


### PR DESCRIPTION
Fixes crash in developer mode login window due to adjustments to `attachEdges` method that reverses the parameters