### PR TITLE
Fixes deprecated pathForResource method.

### DIFF
--- a/ThunderCloud/ContentController.swift
+++ b/ThunderCloud/ContentController.swift
@@ -975,7 +975,19 @@ public extension ContentController {
         }
         
         if let deltaDirectory = deltaDirectory {
-            cacheFile = inDirectory != nil ? "\(deltaDirectory)/\(inDirectory!)/\(forResource).\(withExtension)" : "\(deltaDirectory)/\(forResource).\(withExtension)"
+            
+            let cacheURL: URL
+            if let _inDirectory = inDirectory {
+                cacheURL = deltaDirectory.appendingPathComponent(_inDirectory).appendingPathComponent(forResource).appendingPathExtension(withExtension)
+            } else {
+                cacheURL = deltaDirectory.appendingPathComponent(forResource).appendingPathExtension(withExtension)
+            }
+            
+            if cacheURL.isFileURL {
+                cacheFile = cacheURL.path
+            } else {
+                cacheFile = cacheURL.absoluteString
+            }
         }
         
         if let _cacheFile = cacheFile, FileManager.default.fileExists(atPath: _cacheFile) {


### PR DESCRIPTION
Fixes legacy path for resource method so it returns and checks for valid paths.

Whilst this is deprecated, it was causing issues in Blood due to it not returning valid string-based paths... For example `cacheFile` looked like so `file://some/file/path/StormDeltaBundle/data//frames.json` which is not valid for methods such as `fileExists(atPath:)`.

At some point we should consider removing this method altogether.