### PR TITLE
Fixes final/open/public delcarations for Swift 4.2

### DIFF
--- a/ThunderCloud/AchievementDisplayView.swift
+++ b/ThunderCloud/AchievementDisplayView.swift
@@ -27,7 +27,7 @@ public protocol AchievementDisplayable {
 open class AchievementDisplayView: UIView, AchievementDisplayable {
 	
 	/// A view representation of the subtitle, this is layed out under the image.
-	open let subtitleLabel: UITextView = UITextView()
+    public let subtitleLabel: UITextView = UITextView()
 	
 	private let badgeImageView: UIImageView
 	

--- a/ThunderCloud/Badge.swift
+++ b/ThunderCloud/Badge.swift
@@ -13,19 +13,19 @@ import Foundation
 open class Badge: NSObject, StormObjectProtocol {
 	
 	/// A string of text that is displayed when the badge is unlocked
-	open let completionText: String?
+    public let completionText: String?
 	
 	/// A string of text which informs the user how to unlock the badge
-	open let howToEarnText: String?
+    public let howToEarnText: String?
 	
 	/// The text that is used when the user shares the badge
-	@objc open let shareMessage: String?
+    @objc public let shareMessage: String?
 	
 	/// The title of the badge
-	@objc open let title: String?
+    @objc public let title: String?
 	
 	/// The unique identifier for the badge
-	open let id: String?
+    public let id: String?
 	
 	/// A `Dictionary` representation of the badge's icon, this can be converted to a `TSCImage` to return the `UIImage` representation of the icon
 	private var iconObject: Any?

--- a/ThunderCloud/GridItem.swift
+++ b/ThunderCloud/GridItem.swift
@@ -17,16 +17,16 @@ open class GridItem: CollectionItemDisplayable, StormObjectProtocol {
 	}
 	
 	/// A `StormLink` which determines what the item does when it is selected
-	open let link: StormLink?
+    public let link: StormLink?
 	
 	/// The image to be displayed when displaying this item in a `UICollectionView`
 	open var image: UIImage?
 	
 	/// The title to be displayed when displaying this item in a `UICollectionView`
-	open let title: String?
+    public let title: String?
 	
 	/// The description to be displayed when displaying this item in a `UICollectionView`
-	open let description: String?
+    public let description: String?
 	
 	public required init?(dictionary: [AnyHashable : Any]) {
 		


### PR DESCRIPTION
Fixes warnings about let variables. let is implicitly final so these properties must be declared public instead of open.