### PR TITLE
Fixes premature `viewDidLoad` in `GridPage`

### DIFF
--- a/ThunderCloud/GridPage.swift
+++ b/ThunderCloud/GridPage.swift
@@ -52,7 +52,6 @@ open class GridPage: CollectionViewController, StormObjectProtocol {
 		
 		super.init(collectionViewLayout: UICollectionViewFlowLayout())
 		
-		columns = 2
 		attributes = dictionary["attributes"] as? [[AnyHashable : Any]]
 		
 		if let titleDict = dictionary["title"] as? [AnyHashable : Any], let titleContentKey = titleDict["content"] as? String {
@@ -79,6 +78,9 @@ open class GridPage: CollectionViewController, StormObjectProtocol {
 	open override func viewDidLoad() {
 		
 		super.viewDidLoad()
+        
+        columns = 2
+        
 		collectionView?.backgroundColor = ThemeManager.shared.theme.backgroundColor
 		collectionView?.alwaysBounceVertical = true
         


### PR DESCRIPTION
Fixes init method of GridPage causing `viewDidLoad` to be called prematurely, this was being caused because when setting `columns` `CollectionViewController` calls `invalidateLayout` on it's collection view.