### PR TITLE
Fixes spotlight cutting off top and bottom of image

### DIFF
--- a/ThunderCloud/SpotlightListItem.swift
+++ b/ThunderCloud/SpotlightListItem.swift
@@ -48,7 +48,23 @@ open class SpotlightListItem: ListItem {
 		
 		spotlightCell.spotlights = spotlights
 		spotlightCell.delegate = self
+        
+        if let imageHeight = imageHeight(constrainedTo: tableViewController.view.frame.width) {
+            spotlightCell.heightConstraint?.constant = imageHeight
+        } else {
+            spotlightCell.heightConstraint?.constant = 160
+        }
 	}
+    
+    open func imageHeight(constrainedTo width: CGFloat) -> CGFloat? {
+        guard let image = spotlights?.first?.image else { return nil }
+        let aspectRatio = image.size.height / image.size.width
+        return aspectRatio * width
+    }
+    
+    override open var estimatedHeight: CGFloat? {
+        return imageHeight(constrainedTo: UIScreen.main.bounds.width)
+    }
 }
 
 extension SpotlightListItem: SpotlightListItemCellDelegate {

--- a/ThunderCloud/SpotlightListItemCell.swift
+++ b/ThunderCloud/SpotlightListItemCell.swift
@@ -28,7 +28,9 @@ open class SpotlightListItemCell: StormTableViewCell {
 	
 	@IBOutlet private weak var pageIndicator: UIPageControl!
 	
-	weak var delegate: SpotlightListItemCellDelegate?
+    @IBOutlet weak var heightConstraint: NSLayoutConstraint!
+    
+    weak var delegate: SpotlightListItemCellDelegate?
 	
 	var currentPage: Int = 0 {
 		didSet {

--- a/ThunderCloud/SpotlightListItemCell.xib
+++ b/ThunderCloud/SpotlightListItemCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,7 +32,7 @@
                         </collectionViewFlowLayout>
                     </collectionView>
                     <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="gkm-9D-0WC">
-                        <rect key="frame" x="141" y="129" width="39" height="37"/>
+                        <rect key="frame" x="140.5" y="129" width="39" height="37"/>
                         <connections>
                             <action selector="handlePageControl:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="4dj-j2-Fk6"/>
                         </connections>
@@ -48,6 +49,7 @@
             </tableViewCellContentView>
             <connections>
                 <outlet property="collectionView" destination="BIQ-Y6-P8a" id="s00-MG-fDU"/>
+                <outlet property="heightConstraint" destination="5ci-uU-wZU" id="6Br-GI-4ch"/>
                 <outlet property="pageIndicator" destination="gkm-9D-0WC" id="eD2-Qc-6aT"/>
             </connections>
             <point key="canvasLocation" x="-182" y="61.5"/>


### PR DESCRIPTION
Adds functions to SpotlightListItem to size spotlight based on aspect ratio of it's first item, and allows it to be overridable