### PR TITLE
Fix/different navigation structures

### DIFF
--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -116,22 +116,27 @@ open class ListItem: StormObject, Row {
 	}
 	
 	open func handleSelection(of row: Row, at indexPath: IndexPath, in tableView: UITableView) {
+        
+        guard let parentNavigationController = parentNavigationController else { return }
+        
+        var listPage: ListPage?
+        
+        switch parentNavigationController.visibleViewController {
+        case let accordionTabBarViewController as AccordionTabBarViewController:
+            listPage = accordionTabBarViewController.selectedViewController as? ListPage
+        case let tabbedViewController as NavigationTabBarViewController:
+            listPage = tabbedViewController.selectedViewController as? ListPage
+        case let _listPage as ListPage:
+            listPage = _listPage
+        case let tabBarController as UITabBarController:
+            listPage = tabBarController.selectedViewController as? ListPage
+        case let navigationController as UINavigationController:
+            listPage = navigationController.visibleViewController as? ListPage
+        default:
+            return
+        }
 		
-		if let accordionTabBarViewController = parentNavigationController?.visibleViewController as? AccordionTabBarViewController {
-			
-			if let listPage = accordionTabBarViewController.selectedViewController as? ListPage {
-				listPage.handleSelection(of: row, at: indexPath, in: tableView)
-			}
-			
-		} else if let tabbedViewController = parentNavigationController?.visibleViewController as? NavigationTabBarViewController {
-			
-			if let listPage = tabbedViewController.selectedViewController as? ListPage {
-				listPage.handleSelection(of: row, at: indexPath, in: tableView)
-			}
-			
-		} else if let listPage = parentNavigationController?.visibleViewController as? ListPage {
-			listPage.handleSelection(of: row, at: indexPath, in: tableView)
-		}
+        listPage?.handleSelection(of: row, at: indexPath, in: tableView)
 	}
 	
 	open func height(constrainedTo size: CGSize, in tableView: UITableView) -> CGFloat? {

--- a/ThunderCloud/ListItem.swift
+++ b/ThunderCloud/ListItem.swift
@@ -9,6 +9,18 @@
 import UIKit
 import ThunderTable
 
+/// A protocol that allows view controllers (And other objects if you wish) respond to row selection!
+public protocol RowSelectable {
+    /// handleSelection is called when an item in the table view is selected.
+    /// An action is performed based on the `StormLink` which is passed in with the selection.
+    ///
+    /// - Parameters:
+    ///   - row: The row which was selected
+    ///   - indexPath: The indexPath of that row
+    ///   - tableView: The table view the selection happened at
+    func handleSelection(of row: Row, at indexPath: IndexPath, in tableView: UITableView)
+}
+
 /// ListItem is the base object for displaying table rows in storm.
 /// It complies to the `Row` protocol
 open class ListItem: StormObject, Row {
@@ -119,24 +131,24 @@ open class ListItem: StormObject, Row {
         
         guard let parentNavigationController = parentNavigationController else { return }
         
-        var listPage: ListPage?
+        var rowSelectable: RowSelectable?
         
         switch parentNavigationController.visibleViewController {
         case let accordionTabBarViewController as AccordionTabBarViewController:
-            listPage = accordionTabBarViewController.selectedViewController as? ListPage
+            rowSelectable = accordionTabBarViewController.selectedViewController as? RowSelectable
         case let tabbedViewController as NavigationTabBarViewController:
-            listPage = tabbedViewController.selectedViewController as? ListPage
-        case let _listPage as ListPage:
-            listPage = _listPage
+            rowSelectable = tabbedViewController.selectedViewController as? RowSelectable
+        case let _listPage as RowSelectable:
+            rowSelectable = _listPage
         case let tabBarController as UITabBarController:
-            listPage = tabBarController.selectedViewController as? ListPage
+            rowSelectable = tabBarController.selectedViewController as? RowSelectable
         case let navigationController as UINavigationController:
-            listPage = navigationController.visibleViewController as? ListPage
+            rowSelectable = navigationController.visibleViewController as? RowSelectable
         default:
             return
         }
 		
-        listPage?.handleSelection(of: row, at: indexPath, in: tableView)
+        rowSelectable?.handleSelection(of: row, at: indexPath, in: tableView)
 	}
 	
 	open func height(constrainedTo size: CGSize, in tableView: UITableView) -> CGFloat? {

--- a/ThunderCloud/ListPage.swift
+++ b/ThunderCloud/ListPage.swift
@@ -12,7 +12,7 @@ import ThunderBasics
 import ThunderTable
 
 /// `ListPage` is a subclass of `TableViewController` that lays out storm table view content
-open class ListPage: TableViewController, StormObjectProtocol, TSCCoreSpotlightIndexItem {
+open class ListPage: TableViewController, StormObjectProtocol, TSCCoreSpotlightIndexItem, RowSelectable {
 
     //MARK: -
 	//MARK: Public API


### PR DESCRIPTION
This was done to fix an issue for a particular client where because one of the root tabs was subclassing from `UIViewController` as apposed to `ListPage` as well as the navigation structure not being constructed by storm, links weren't reacting to touches!