### PR TITLE
Checks for appId before launching dev mode login

### DIFF
--- a/ThunderCloud/DeveloperModeController.swift
+++ b/ThunderCloud/DeveloperModeController.swift
@@ -84,7 +84,7 @@ public class DeveloperModeController: NSObject {
         
         backgroundObserver = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: OperationQueue.main, using: { [weak self] (notification) in
             
-            // Make sure we have an app ID before entering developer mode, now that we have apps who download their bundle rather
+            // Make sure we have an app I and app.json before entering developer mode, now that we have apps who download their bundle rather
             // than being bundled with it.
             if DeveloperModeController.devModeOn, ContentController.shared.fileExistsInBundle(file: "app.json"),  UserDefaults.standard.string(forKey: "TSCAppId") ?? API_APPID != nil {
                 self?.loginToDeveloperMode()

--- a/ThunderCloud/DeveloperModeController.swift
+++ b/ThunderCloud/DeveloperModeController.swift
@@ -84,7 +84,9 @@ public class DeveloperModeController: NSObject {
         
         backgroundObserver = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: OperationQueue.main, using: { [weak self] (notification) in
             
-            if DeveloperModeController.devModeOn {
+            // Make sure we have an app ID before entering developer mode, now that we have apps who download their bundle rather
+            // than being bundled with it.
+            if DeveloperModeController.devModeOn, ContentController.shared.fileExistsInBundle(file: "app.json"),  UserDefaults.standard.string(forKey: "TSCAppId") ?? API_APPID != nil {
                 self?.loginToDeveloperMode()
             } else if !DeveloperModeController.devModeOn && DeveloperModeController.appIsInDevMode {
                 self?.switchToLive()

--- a/ThunderCloud/DeveloperModeController.swift
+++ b/ThunderCloud/DeveloperModeController.swift
@@ -84,9 +84,13 @@ public class DeveloperModeController: NSObject {
         
         backgroundObserver = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: OperationQueue.main, using: { [weak self] (notification) in
             
-            // Make sure we have an app ID and app.json before entering developer mode, now that we have apps who download their bundle rather
-            // than being bundled with it.
-            if DeveloperModeController.devModeOn, ContentController.shared.fileExistsInBundle(file: "app.json"),  UserDefaults.standard.string(forKey: "TSCAppId") ?? API_APPID != nil {
+            // Make sure we have an app ID and app.json before entering/leaving developer mode, now that we have apps
+            // which download their bundle rather than being bundled with it.
+            guard ContentController.shared.fileExistsInBundle(file: "app.json"),  UserDefaults.standard.string(forKey: "TSCAppId") ?? API_APPID != nil else {
+                return
+            }
+            
+            if DeveloperModeController.devModeOn {
                 self?.loginToDeveloperMode()
             } else if !DeveloperModeController.devModeOn && DeveloperModeController.appIsInDevMode {
                 self?.switchToLive()

--- a/ThunderCloud/DeveloperModeController.swift
+++ b/ThunderCloud/DeveloperModeController.swift
@@ -84,7 +84,7 @@ public class DeveloperModeController: NSObject {
         
         backgroundObserver = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: OperationQueue.main, using: { [weak self] (notification) in
             
-            // Make sure we have an app I and app.json before entering developer mode, now that we have apps who download their bundle rather
+            // Make sure we have an app ID and app.json before entering developer mode, now that we have apps who download their bundle rather
             // than being bundled with it.
             if DeveloperModeController.devModeOn, ContentController.shared.fileExistsInBundle(file: "app.json"),  UserDefaults.standard.string(forKey: "TSCAppId") ?? API_APPID != nil {
                 self?.loginToDeveloperMode()


### PR DESCRIPTION
Dev mode cannot be shown before we have an app ID, or app.json because the download will fail, and if the user switches back to live, they will have no content to be displayed if `app.json` is missing