### PR TITLE
Fixing Video Controls layout

### DIFF
--- a/ThunderCloud/MultiVideoPlayerViewController.swift
+++ b/ThunderCloud/MultiVideoPlayerViewController.swift
@@ -127,23 +127,32 @@ open class MultiVideoPlayerViewController: UIViewController {
 		
 		activityIndicator.startAnimating()
 	}
+    
+    private func getBottomSafeAreaInset() -> CGFloat {
+        if #available(iOS 11, *) {
+            return self.view.safeAreaInsets.bottom
+        } else {
+            return 0
+        }
+    }
 	
 	override open func viewWillLayoutSubviews() {
 		
 		super.viewWillLayoutSubviews()
 		
 		videoPlayerLayer?.frame = view.bounds
-		let orientation = UIApplication.shared.statusBarOrientation
+        
+        // Get the bottom safe area inset, so the controls can be shifted upwards on newer devices to remain accessible.
+        let bottomSafeAreaInset = getBottomSafeAreaInset()
+        
+        let orientation = UIApplication.shared.statusBarOrientation
 		
 		if orientation.isPortrait {
-			
-			playerControlsView.frame = CGRect(x: 0, y: view.frame.height - 80, width: view.frame.width, height: 80)
+			playerControlsView.frame = CGRect(x: 0, y: view.frame.height - (80 + bottomSafeAreaInset), width: view.frame.width, height: 80 + bottomSafeAreaInset)
 			videoScrubView.frame = CGRect(x: navigationItem.titleView?.frame.minX ?? 0, y: navigationItem.titleView?.frame.minY ?? 0, width: 210, height: 44)
-			
 		} else {
-			
 			view.bringSubviewToFront(playerControlsView)
-			playerControlsView.frame = CGRect(x: 0, y: view.frame.height - 40, width: view.frame.width, height: 40)
+			playerControlsView.frame = CGRect(x: 0, y: view.frame.height - (40 + bottomSafeAreaInset), width: view.frame.width, height: 40 + bottomSafeAreaInset)
 			videoScrubView.frame = CGRect(x: navigationItem.titleView?.frame.minX ?? 0, y: navigationItem.titleView?.frame.minY ?? 0, width: 400, height: 44)
 		}
 	}

--- a/ThunderCloud/MultiVideoPlayerViewController.swift
+++ b/ThunderCloud/MultiVideoPlayerViewController.swift
@@ -32,101 +32,101 @@ fileprivate extension UIInterfaceOrientation {
 /// Users also have the ability to change the language of their video manually
 @objc(TSCMultiVideoPlayerViewController)
 open class MultiVideoPlayerViewController: UIViewController {
-	
-	fileprivate var player: AVPlayer?
-	
-	private var videoPlayerLayer: AVPlayerLayer?
-	
-	private var retryYouTubeLink: StormLink?
-	
-	private var dontReload = false
-	
-	fileprivate var languageSwitched = false
-	
-	private var originalBarTintColor: UIColor?
-	
-	private let activityIndicator: UIActivityIndicatorView = UIActivityIndicatorView(style: .whiteLarge)
-	
-	private let videos: [Video]
-	
-	private let playerControlsView: VideoPlayerControlsView = VideoPlayerControlsView()
-	
-	private let videoScrubView: TSCVideoScrubViewController = TSCVideoScrubViewController()
-
-	/// Initialises the video player with an array of available videos
-	///
-	/// - Parameter videos: The videos which are available from storm
-	public init(videos: [Video]) {
-		
-		self.videos = videos
-		
-		super.init(nibName: nil, bundle: nil)
-		
-		navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Done".localised(with: "_STORM_VIDEOPLAYER_NAVIGATION_LEFT"), style: .plain, target: self, action: #selector(finishVideo))
-		
-		originalBarTintColor = UINavigationBar.appearance().barTintColor
-		let navigationBar = UINavigationBar.appearance()
-		navigationBar.barTintColor = UIColor(red: 74/255, green: 75/255, blue: 77/255, alpha: 1)
-		
-		playerControlsView.playButton.addTarget(self, action: #selector(playPause(sender:)), for: .touchUpInside)
-		playerControlsView.languageButton?.addTarget(self, action: #selector(changeLanguage(sender:)), for: .touchUpInside)
-		
-		videoScrubView.videoProgressTracker.addTarget(self, action: #selector(progressSliderChanged(sender:)), for: .valueChanged)
-	}
-	
-	required public init?(coder aDecoder: NSCoder) {
-		videos = []
-		super.init(coder: aDecoder)
-	}
-	
-	//MARK: -
-	//MARK: View Controller Lifecycle
-	//MARK: -
-	
-	override open func viewDidAppear(_ animated: Bool) {
-		super.viewDidAppear(animated)
-		
-		if languageSwitched {
-			return
-		}
-		
-		// Try and find a video with the correct locale, falling back to the first video
-		let video = videos.first(where: { (video) -> Bool in
-			
-			guard let locale = video.locale, let link = video.link, locale == StormLanguageController.shared.currentLocale  else {
-				return false
-			}
-			
-			switch link.linkClass {
-				case .external:
-					return true
-				case .internal:
-					return ContentController.shared.url(forCacheURL: link.url) != nil
-				default:
-					return true
-			}
-
-		}) ?? videos.first
-
-		
-		guard video != nil else { return }
-		play(video: video!)
-	}
-	
-	override open func viewDidLoad() {
-		
-		super.viewDidLoad()
-		
-		view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleBars)))
-		view.backgroundColor = .black
-		view.addSubview(playerControlsView)
-		
-		activityIndicator.frame = CGRect(x: 200, y: 200, width: 20, height: 20)
-		activityIndicator.center = view.center
-		view.addSubview(activityIndicator)
-		
-		activityIndicator.startAnimating()
-	}
+    
+    fileprivate var player: AVPlayer?
+    
+    private var videoPlayerLayer: AVPlayerLayer?
+    
+    private var retryYouTubeLink: StormLink?
+    
+    private var dontReload = false
+    
+    fileprivate var languageSwitched = false
+    
+    private var originalBarTintColor: UIColor?
+    
+    private let activityIndicator: UIActivityIndicatorView = UIActivityIndicatorView(style: .whiteLarge)
+    
+    private let videos: [Video]
+    
+    private let playerControlsView: VideoPlayerControlsView = VideoPlayerControlsView()
+    
+    private let videoScrubView: TSCVideoScrubViewController = TSCVideoScrubViewController()
+    
+    /// Initialises the video player with an array of available videos
+    ///
+    /// - Parameter videos: The videos which are available from storm
+    public init(videos: [Video]) {
+        
+        self.videos = videos
+        
+        super.init(nibName: nil, bundle: nil)
+        
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Done".localised(with: "_STORM_VIDEOPLAYER_NAVIGATION_LEFT"), style: .plain, target: self, action: #selector(finishVideo))
+        
+        originalBarTintColor = UINavigationBar.appearance().barTintColor
+        let navigationBar = UINavigationBar.appearance()
+        navigationBar.barTintColor = UIColor(red: 74/255, green: 75/255, blue: 77/255, alpha: 1)
+        
+        playerControlsView.playButton.addTarget(self, action: #selector(playPause(sender:)), for: .touchUpInside)
+        playerControlsView.languageButton?.addTarget(self, action: #selector(changeLanguage(sender:)), for: .touchUpInside)
+        
+        videoScrubView.videoProgressTracker.addTarget(self, action: #selector(progressSliderChanged(sender:)), for: .valueChanged)
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        videos = []
+        super.init(coder: aDecoder)
+    }
+    
+    //MARK: -
+    //MARK: View Controller Lifecycle
+    //MARK: -
+    
+    override open func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        if languageSwitched {
+            return
+        }
+        
+        // Try and find a video with the correct locale, falling back to the first video
+        let video = videos.first(where: { (video) -> Bool in
+            
+            guard let locale = video.locale, let link = video.link, locale == StormLanguageController.shared.currentLocale  else {
+                return false
+            }
+            
+            switch link.linkClass {
+            case .external:
+                return true
+            case .internal:
+                return ContentController.shared.url(forCacheURL: link.url) != nil
+            default:
+                return true
+            }
+            
+        }) ?? videos.first
+        
+        
+        guard video != nil else { return }
+        play(video: video!)
+    }
+    
+    override open func viewDidLoad() {
+        
+        super.viewDidLoad()
+        
+        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(toggleBars)))
+        view.backgroundColor = .black
+        view.addSubview(playerControlsView)
+        
+        activityIndicator.frame = CGRect(x: 200, y: 200, width: 20, height: 20)
+        activityIndicator.center = view.center
+        view.addSubview(activityIndicator)
+        
+        activityIndicator.startAnimating()
+    }
     
     private func getBottomSafeAreaInset() -> CGFloat {
         if #available(iOS 11, *) {
@@ -135,37 +135,37 @@ open class MultiVideoPlayerViewController: UIViewController {
             return 0
         }
     }
-	
-	override open func viewWillLayoutSubviews() {
-		
-		super.viewWillLayoutSubviews()
-		
-		videoPlayerLayer?.frame = view.bounds
+    
+    override open func viewWillLayoutSubviews() {
+        
+        super.viewWillLayoutSubviews()
+        
+        videoPlayerLayer?.frame = view.bounds
         
         // Get the bottom safe area inset, so the controls can be shifted upwards on newer devices to remain accessible.
         let bottomSafeAreaInset = getBottomSafeAreaInset()
         
         let orientation = UIApplication.shared.statusBarOrientation
-		
-		if orientation.isPortrait {
-			playerControlsView.frame = CGRect(x: 0, y: view.frame.height - (80 + bottomSafeAreaInset), width: view.frame.width, height: 80 + bottomSafeAreaInset)
-			videoScrubView.frame = CGRect(x: navigationItem.titleView?.frame.minX ?? 0, y: navigationItem.titleView?.frame.minY ?? 0, width: 210, height: 44)
-		} else {
-			view.bringSubviewToFront(playerControlsView)
-			playerControlsView.frame = CGRect(x: 0, y: view.frame.height - (40 + bottomSafeAreaInset), width: view.frame.width, height: 40 + bottomSafeAreaInset)
-			videoScrubView.frame = CGRect(x: navigationItem.titleView?.frame.minX ?? 0, y: navigationItem.titleView?.frame.minY ?? 0, width: 400, height: 44)
-		}
-	}
-	
-	override open func viewWillDisappear(_ animated: Bool) {
-		
-		super.viewWillDisappear(animated)
-		
-		UINavigationBar.appearance().barTintColor = originalBarTintColor
-		if isBeingDismissed {
-			player = nil
-			videoPlayerLayer?.removeFromSuperlayer()
-		}
+        
+        if orientation.isPortrait {
+            playerControlsView.frame = CGRect(x: 0, y: view.frame.height - (80 + bottomSafeAreaInset), width: view.frame.width, height: 80 + bottomSafeAreaInset)
+            videoScrubView.frame = CGRect(x: navigationItem.titleView?.frame.minX ?? 0, y: navigationItem.titleView?.frame.minY ?? 0, width: 210, height: 44)
+        } else {
+            view.bringSubviewToFront(playerControlsView)
+            playerControlsView.frame = CGRect(x: 0, y: view.frame.height - (40 + bottomSafeAreaInset), width: view.frame.width, height: 40 + bottomSafeAreaInset)
+            videoScrubView.frame = CGRect(x: navigationItem.titleView?.frame.minX ?? 0, y: navigationItem.titleView?.frame.minY ?? 0, width: 400, height: 44)
+        }
+    }
+    
+    override open func viewWillDisappear(_ animated: Bool) {
+        
+        super.viewWillDisappear(animated)
+        
+        UINavigationBar.appearance().barTintColor = originalBarTintColor
+        if isBeingDismissed {
+            player = nil
+            videoPlayerLayer?.removeFromSuperlayer()
+        }
         
         // If we can't get the supported orientations rotate away as we don't want to make any assumptions
         guard let supportedOrientationStrings = Bundle.main.infoDictionary?["UISupportedInterfaceOrientations"] as? [String] else {
@@ -179,253 +179,253 @@ open class MultiVideoPlayerViewController: UIViewController {
             rotateDeviceToPortrait()
             return
         }
-		
+        
         guard !supportedOrientations.contains(UIApplication.shared.statusBarOrientation) else {
             return
         }
         
-		rotateDeviceToPortrait()
-	}
+        rotateDeviceToPortrait()
+    }
     
     private func rotateDeviceToPortrait() {
         UIDevice.current.setValue(Int(UIInterfaceOrientation.portrait.rawValue), forKey: "orientation")
     }
-	
-	//MARK: -
-	//MARK: Helper Functions
-	//MARK: -
-	
-	@objc private func timeoutVideoLoad() {
-		dontReload = true
-	}
-	
-	fileprivate func play(video: Video) {
-		
-		guard let videoLink = video.link else {
-			dismissAnimated()
-			return
-		}
-		
-		switch videoLink.linkClass {
-			case .external:
-				loadYouTubeVideo(for: videoLink)
-				NotificationCenter.default.sendStatEventNotification(category: "Video", action: "YouTube - \(videoLink.url?.absoluteString ?? "Unknown")", label: nil, value: nil, object: self)
-				break
-			case .internal:
-				guard let path =  ContentController.shared.url(forCacheURL: videoLink.url) else {
-					dismissAnimated()
-					return
-				}
-				NotificationCenter.default.sendStatEventNotification(category: "Video", action: "Local - \(videoLink.title ?? "Unknown")", label: nil, value: nil, object: self)
-				playVideo(at: path)
-				break
-			default:
-				return
-		}
-	}
-	
-	private func playVideo(at url: URL) {
-		
-		// Delete the old player and layer
-		player = nil
-		videoPlayerLayer = nil
-		
-		player = AVPlayer(url: url)
-		player?.volume = 0.5
-		videoPlayerLayer = AVPlayerLayer(player: player!)
-		videoPlayerLayer?.videoGravity = .resizeAspect
-		videoPlayerLayer?.frame = view.bounds
-		
-		view.layer.sublayers?.forEach({ (layer) in
-			guard let playerLayer = layer as? AVPlayerLayer else { return }
-			playerLayer.removeFromSuperlayer()
-		})
-		
-		view.layer.addSublayer(videoPlayerLayer!)
-		player?.play()
-		
-		let interval = CMTime(seconds: 0.5, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-		
-		player?.addPeriodicTimeObserver(forInterval: interval, queue: .main, using: { [weak self] (time) in
-			
-			guard let welf = self, let player = welf.player, let currentItem = player.currentItem else { return }
-			
-			let endTime = CMTimeConvertScale(currentItem.asset.duration, timescale: player.currentTime().timescale, method: .roundHalfAwayFromZero)
-			
-			if CMTimeCompare(endTime, CMTime.zero) != 0 {
-				
-				// Time progressed
-				let timeProgressed: TimeInterval = CMTimeGetSeconds(player.currentTime())
-				
-				let formatter = DateComponentsFormatter()
-				formatter.unitsStyle = .positional
-				formatter.allowedUnits = [ .minute, .second ]
-				formatter.zeroFormattingBehavior = [ .pad ]
-				
-				welf.videoScrubView.currentTimeLabel.text = formatter.string(from: timeProgressed)
-				
-				// End time
-				if CMTimeCompare(CMTime.zero, currentItem.duration) != 0 {
-					let totalTime: TimeInterval = CMTimeGetSeconds(currentItem.duration)
-					if !totalTime.isNaN {
-						welf.videoScrubView.endTimeLabel.text = formatter.string(from: totalTime)
-					}
-				}
-				welf.videoScrubView.videoProgressTracker.maximumValue = Float(CMTimeGetSeconds(currentItem.asset.duration))
-				welf.videoScrubView.videoProgressTracker.value = Float(timeProgressed)
-			}
-		})
-	}
-	
-	private func loadYouTubeVideo(for link: StormLink) {
-		
-		guard let url = link.url else {
-			dismissAnimated()
-			print("[MultiVideoPlayerViewController] No url present on YouTube link!")
-			return
-		}
-		
-		YouTubeController.loadVideo(for: url) { [weak self] (youtubeURL, error) in
-			
-			guard let strongSelf = self else { return }
-			
-			guard let youtubeURL = youtubeURL else {
-				
-				if let controllerError = error as? YouTubeControllerError {
-					
-					switch controllerError {
+    
+    //MARK: -
+    //MARK: Helper Functions
+    //MARK: -
+    
+    @objc private func timeoutVideoLoad() {
+        dontReload = true
+    }
+    
+    fileprivate func play(video: Video) {
+        
+        guard let videoLink = video.link else {
+            dismissAnimated()
+            return
+        }
+        
+        switch videoLink.linkClass {
+        case .external:
+            loadYouTubeVideo(for: videoLink)
+            NotificationCenter.default.sendStatEventNotification(category: "Video", action: "YouTube - \(videoLink.url?.absoluteString ?? "Unknown")", label: nil, value: nil, object: self)
+            break
+        case .internal:
+            guard let path =  ContentController.shared.url(forCacheURL: videoLink.url) else {
+                dismissAnimated()
+                return
+            }
+            NotificationCenter.default.sendStatEventNotification(category: "Video", action: "Local - \(videoLink.title ?? "Unknown")", label: nil, value: nil, object: self)
+            playVideo(at: path)
+            break
+        default:
+            return
+        }
+    }
+    
+    private func playVideo(at url: URL) {
+        
+        // Delete the old player and layer
+        player = nil
+        videoPlayerLayer = nil
+        
+        player = AVPlayer(url: url)
+        player?.volume = 0.5
+        videoPlayerLayer = AVPlayerLayer(player: player!)
+        videoPlayerLayer?.videoGravity = .resizeAspect
+        videoPlayerLayer?.frame = view.bounds
+        
+        view.layer.sublayers?.forEach({ (layer) in
+            guard let playerLayer = layer as? AVPlayerLayer else { return }
+            playerLayer.removeFromSuperlayer()
+        })
+        
+        view.layer.addSublayer(videoPlayerLayer!)
+        player?.play()
+        
+        let interval = CMTime(seconds: 0.5, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+        
+        player?.addPeriodicTimeObserver(forInterval: interval, queue: .main, using: { [weak self] (time) in
+            
+            guard let welf = self, let player = welf.player, let currentItem = player.currentItem else { return }
+            
+            let endTime = CMTimeConvertScale(currentItem.asset.duration, timescale: player.currentTime().timescale, method: .roundHalfAwayFromZero)
+            
+            if CMTimeCompare(endTime, CMTime.zero) != 0 {
+                
+                // Time progressed
+                let timeProgressed: TimeInterval = CMTimeGetSeconds(player.currentTime())
+                
+                let formatter = DateComponentsFormatter()
+                formatter.unitsStyle = .positional
+                formatter.allowedUnits = [ .minute, .second ]
+                formatter.zeroFormattingBehavior = [ .pad ]
+                
+                welf.videoScrubView.currentTimeLabel.text = formatter.string(from: timeProgressed)
+                
+                // End time
+                if CMTimeCompare(CMTime.zero, currentItem.duration) != 0 {
+                    let totalTime: TimeInterval = CMTimeGetSeconds(currentItem.duration)
+                    if !totalTime.isNaN {
+                        welf.videoScrubView.endTimeLabel.text = formatter.string(from: totalTime)
+                    }
+                }
+                welf.videoScrubView.videoProgressTracker.maximumValue = Float(CMTimeGetSeconds(currentItem.asset.duration))
+                welf.videoScrubView.videoProgressTracker.value = Float(timeProgressed)
+            }
+        })
+    }
+    
+    private func loadYouTubeVideo(for link: StormLink) {
+        
+        guard let url = link.url else {
+            dismissAnimated()
+            print("[MultiVideoPlayerViewController] No url present on YouTube link!")
+            return
+        }
+        
+        YouTubeController.loadVideo(for: url) { [weak self] (youtubeURL, error) in
+            
+            guard let strongSelf = self else { return }
+            
+            guard let youtubeURL = youtubeURL else {
+                
+                if let controllerError = error as? YouTubeControllerError {
+                    
+                    switch controllerError {
                     case .noValidMimeTypesFound:
                         fallthrough
-					case .responseDataInvalid:
-						fallthrough
-					case .invalidURL:
-						fallthrough
-					case .failedCreatingURLComponents:
-						fallthrough
-					case .failedConstructingURL:
+                    case .responseDataInvalid:
+                        fallthrough
+                    case .invalidURL:
+                        fallthrough
+                    case .failedCreatingURLComponents:
+                        fallthrough
+                    case .failedConstructingURL:
                         OperationQueue.main.addOperation {
                             strongSelf.dismissAnimated()
                         }
-						return
-					case .noStreamMapFound:
-						fallthrough
-					case .noValidQualityFound:
-						fallthrough
-					case .finalURLInvalid:
-						fallthrough
-					case .responseDataTooShort:
-						
-						strongSelf.retryYouTubeLink = link
-						
-						if strongSelf.dontReload {
+                        return
+                    case .noStreamMapFound:
+                        fallthrough
+                    case .noValidQualityFound:
+                        fallthrough
+                    case .finalURLInvalid:
+                        fallthrough
+                    case .responseDataTooShort:
+                        
+                        strongSelf.retryYouTubeLink = link
+                        
+                        if strongSelf.dontReload {
                             OperationQueue.main.addOperation {
                                 strongSelf.showRetryAlert()
                             }
-						} else {
-							strongSelf.loadYouTubeVideo(for: link)
-						}
-						
-						return
-					}
-					
-				} else {
-					
-					strongSelf.retryYouTubeLink = link
-					
-					if strongSelf.dontReload {
+                        } else {
+                            strongSelf.loadYouTubeVideo(for: link)
+                        }
+                        
+                        return
+                    }
+                    
+                } else {
+                    
+                    strongSelf.retryYouTubeLink = link
+                    
+                    if strongSelf.dontReload {
                         OperationQueue.main.addOperation {
                             strongSelf.showRetryAlert()
                         }
-					} else {
-						strongSelf.loadYouTubeVideo(for: link)
-					}
-				}
-				
-				return
-			}
-			
-			OperationQueue.main.addOperation {
-				strongSelf.playVideo(at: youtubeURL)
-			}
-		}
-	}
-	
-	private func showRetryAlert() {
-		
-		let unableToPlayAlert = UIAlertController(
-			title: "An error has occured".localised(with: "_STORM_VIDEOPLAYER_ERROR_TITLE"),
-			message: "Sorry, we are unable to play this video. Please try again".localised(with: "_STORM_VIDEOPLAYER_ERROR_MESSAGE"),
-			preferredStyle: .alert
-		)
-		
-		unableToPlayAlert.addAction(UIAlertAction(
-			title: "Okay".localised(with: "_STORM_VIDEOPLAYER_ERROR_BUTTON_OKAY"),
-			style: .cancel,
-			handler: nil)
-		)
-		
-		unableToPlayAlert.addAction(UIAlertAction(
-			title: "Retry".localised(with: "_STORM_VIDEOPLAYER_ERROR_BUTTON_RETRY"),
-			style: .default,
-			handler: { (action) in
-				
-				Timer.scheduledTimer(timeInterval: 60.0, target: self, selector: #selector(self.timeoutVideoLoad), userInfo: nil, repeats: false)
-				guard let retryLink = self.retryYouTubeLink else {
-					return
-				}
-				self.loadYouTubeVideo(for: retryLink)
-			}
-		))
-		
-		present(unableToPlayAlert, animated: true, completion: nil)
-	}
-	
-	//MARK: -
-	//MARK: Action Handlers
-	//MARK: -
-	@objc private func finishVideo() {
-		player?.pause()
-		dismissAnimated()
-	}
-	
-	@objc private func playPause(sender: UIButton) {
-		
-		guard let player = player else { return }
-		
-		let bundle = Bundle(for: MultiVideoPlayerViewController.self)
-		
-		if player.rate == 0 {
-			let image = UIImage(named: "mediaPauseButton", in: bundle, compatibleWith: nil)
-			sender.setImage(image, for: .normal)
-			player.play()
-		} else {
-			let image = UIImage(named: "mediaPlayButton", in: bundle, compatibleWith: nil)
-			sender.setImage(image, for: .normal)
-			player.pause()
-		}
-	}
-	
-	@objc private func changeLanguage(sender: UIButton) {
-		
-		let selectLanguageViewController = VideoLanguageSelectionViewController(videos: videos)
-		selectLanguageViewController.videoSelectionDelegate = self
-		
-		let navController = UINavigationController(rootViewController: selectLanguageViewController)
-		present(navController, animated: true, completion: nil)
-	}
-	
-	@objc private func toggleBars() {
-		
-		guard let navController = navigationController else { return }
-		
-		let barHidden = navController.isNavigationBarHidden
-		navController.setNavigationBarHidden(!barHidden, animated: true)
-		playerControlsView.isHidden = !barHidden
-	}
-	
-	@objc private func progressSliderChanged(sender: UISlider) {
-		player?.seek(to: CMTimeMake(value: Int64(sender.value), timescale: 1))
-	}
+                    } else {
+                        strongSelf.loadYouTubeVideo(for: link)
+                    }
+                }
+                
+                return
+            }
+            
+            OperationQueue.main.addOperation {
+                strongSelf.playVideo(at: youtubeURL)
+            }
+        }
+    }
+    
+    private func showRetryAlert() {
+        
+        let unableToPlayAlert = UIAlertController(
+            title: "An error has occured".localised(with: "_STORM_VIDEOPLAYER_ERROR_TITLE"),
+            message: "Sorry, we are unable to play this video. Please try again".localised(with: "_STORM_VIDEOPLAYER_ERROR_MESSAGE"),
+            preferredStyle: .alert
+        )
+        
+        unableToPlayAlert.addAction(UIAlertAction(
+            title: "Okay".localised(with: "_STORM_VIDEOPLAYER_ERROR_BUTTON_OKAY"),
+            style: .cancel,
+            handler: nil)
+        )
+        
+        unableToPlayAlert.addAction(UIAlertAction(
+            title: "Retry".localised(with: "_STORM_VIDEOPLAYER_ERROR_BUTTON_RETRY"),
+            style: .default,
+            handler: { (action) in
+                
+                Timer.scheduledTimer(timeInterval: 60.0, target: self, selector: #selector(self.timeoutVideoLoad), userInfo: nil, repeats: false)
+                guard let retryLink = self.retryYouTubeLink else {
+                    return
+                }
+                self.loadYouTubeVideo(for: retryLink)
+        }
+        ))
+        
+        present(unableToPlayAlert, animated: true, completion: nil)
+    }
+    
+    //MARK: -
+    //MARK: Action Handlers
+    //MARK: -
+    @objc private func finishVideo() {
+        player?.pause()
+        dismissAnimated()
+    }
+    
+    @objc private func playPause(sender: UIButton) {
+        
+        guard let player = player else { return }
+        
+        let bundle = Bundle(for: MultiVideoPlayerViewController.self)
+        
+        if player.rate == 0 {
+            let image = UIImage(named: "mediaPauseButton", in: bundle, compatibleWith: nil)
+            sender.setImage(image, for: .normal)
+            player.play()
+        } else {
+            let image = UIImage(named: "mediaPlayButton", in: bundle, compatibleWith: nil)
+            sender.setImage(image, for: .normal)
+            player.pause()
+        }
+    }
+    
+    @objc private func changeLanguage(sender: UIButton) {
+        
+        let selectLanguageViewController = VideoLanguageSelectionViewController(videos: videos)
+        selectLanguageViewController.videoSelectionDelegate = self
+        
+        let navController = UINavigationController(rootViewController: selectLanguageViewController)
+        present(navController, animated: true, completion: nil)
+    }
+    
+    @objc private func toggleBars() {
+        
+        guard let navController = navigationController else { return }
+        
+        let barHidden = navController.isNavigationBarHidden
+        navController.setNavigationBarHidden(!barHidden, animated: true)
+        playerControlsView.isHidden = !barHidden
+    }
+    
+    @objc private func progressSliderChanged(sender: UISlider) {
+        player?.seek(to: CMTimeMake(value: Int64(sender.value), timescale: 1))
+    }
 }
 
 
@@ -433,13 +433,13 @@ open class MultiVideoPlayerViewController: UIViewController {
 //MARK: VideoLanguageSelectionViewControllerDelegate
 //MARK: -
 extension MultiVideoPlayerViewController: VideoLanguageSelectionViewControllerDelegate {
-	
-	public func selectionViewController(viewController: VideoLanguageSelectionViewController, didSelect video: Video) {
-		
-		languageSwitched = true
-		dontReload = false
-		player?.pause()
-		viewController.dismissAnimated()
-		play(video: video)
-	}
+    
+    public func selectionViewController(viewController: VideoLanguageSelectionViewController, didSelect video: Video) {
+        
+        languageSwitched = true
+        dontReload = false
+        player?.pause()
+        viewController.dismissAnimated()
+        play(video: video)
+    }
 }

--- a/ThunderCloud/VideoPlayerControlsView.swift
+++ b/ThunderCloud/VideoPlayerControlsView.swift
@@ -45,10 +45,20 @@ open class VideoPlayerControlsView: UIView {
 	public required init?(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 	}
+    
+    private func getBottomSafeAreaInset() -> CGFloat {
+        if #available(iOS 11, *) {
+            return self.safeAreaInsets.bottom
+        } else {
+            return 0
+        }
+    }
 	
 	override open func layoutSubviews() {
 		
 		super.layoutSubviews()
+        
+        let bottomSafeAreaInset = getBottomSafeAreaInset()
 		let orientation = UIApplication.shared.statusBarOrientation
 		
 		if orientation.isPortrait {
@@ -63,7 +73,7 @@ open class VideoPlayerControlsView: UIView {
 				playButton.frame = CGRect(x: frame.width/2 - 12, y: 10, width: 24, height: 26)
 			}
 
-			volumeView.frame = CGRect(x: 44, y: bounds.height - 30, width: bounds.width - 88, height: 22)
+			volumeView.frame = CGRect(x: 44, y: bounds.height - (30 + bottomSafeAreaInset), width: bounds.width - 88, height: 22)
 			
 		} else {
 			
@@ -78,7 +88,7 @@ open class VideoPlayerControlsView: UIView {
 			}
 			
 			
-			volumeView.frame = CGRect(x: 20, y: bounds.size.height - 30, width: bounds.width/2 - 50, height: 22)
+			volumeView.frame = CGRect(x: 20, y: bounds.size.height - (30 + bottomSafeAreaInset), width: bounds.width/2 - 50, height: 22)
 		}
 	}
 }

--- a/ThunderCloud/VideoPlayerControlsView.swift
+++ b/ThunderCloud/VideoPlayerControlsView.swift
@@ -11,40 +11,40 @@ import MediaPlayer
 
 /// The view shown over/below a full screen video that displays video controls
 open class VideoPlayerControlsView: UIView {
-
-	/// The volume control for adjusting the video volume or switching to an Airplay device
-	open var volumeView: MPVolumeView = MPVolumeView()
-	
-	/// The play/pause button for the video
-	open var playButton: UIButton = UIButton()
-	
-	/// Where multiple languages are available, this button is available for choosing the video in an alternative language
-	open var languageButton: UIButton?
-	
-	public init() {
-		
-		super.init(frame: .zero)
-		
-		backgroundColor = UIColor(red: 74.0/255.0, green: 75.0/255.0, blue: 77.0/255.0, alpha: 1.0)
-		
-		let playImage = UIImage(named: "mediaPauseButton", in: Bundle.init(for: VideoPlayerControlsView.self), compatibleWith: nil)
-		playButton.setImage(playImage, for: .normal)
-		addSubview(playButton)
-		
-		if let languagePacks = StormLanguageController.shared.availableLanguagePacks, languagePacks.count > 1 {
-			
-			languageButton = UIButton()
-			let languageImage = UIImage(named: "mediaLanguageButton", in: Bundle.init(for: VideoPlayerControlsView.self), compatibleWith: nil)
-			languageButton?.setImage(languageImage, for: .normal)
-			addSubview(languageButton!)
-		}
-		
-		addSubview(volumeView)
-	}
-	
-	public required init?(coder aDecoder: NSCoder) {
-		super.init(coder: aDecoder)
-	}
+    
+    /// The volume control for adjusting the video volume or switching to an Airplay device
+    open var volumeView: MPVolumeView = MPVolumeView()
+    
+    /// The play/pause button for the video
+    open var playButton: UIButton = UIButton()
+    
+    /// Where multiple languages are available, this button is available for choosing the video in an alternative language
+    open var languageButton: UIButton?
+    
+    public init() {
+        
+        super.init(frame: .zero)
+        
+        backgroundColor = UIColor(red: 74.0/255.0, green: 75.0/255.0, blue: 77.0/255.0, alpha: 1.0)
+        
+        let playImage = UIImage(named: "mediaPauseButton", in: Bundle.init(for: VideoPlayerControlsView.self), compatibleWith: nil)
+        playButton.setImage(playImage, for: .normal)
+        addSubview(playButton)
+        
+        if let languagePacks = StormLanguageController.shared.availableLanguagePacks, languagePacks.count > 1 {
+            
+            languageButton = UIButton()
+            let languageImage = UIImage(named: "mediaLanguageButton", in: Bundle.init(for: VideoPlayerControlsView.self), compatibleWith: nil)
+            languageButton?.setImage(languageImage, for: .normal)
+            addSubview(languageButton!)
+        }
+        
+        addSubview(volumeView)
+    }
+    
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
     
     private func getBottomSafeAreaInset() -> CGFloat {
         if #available(iOS 11, *) {
@@ -53,42 +53,42 @@ open class VideoPlayerControlsView: UIView {
             return 0
         }
     }
-	
-	override open func layoutSubviews() {
-		
-		super.layoutSubviews()
+    
+    override open func layoutSubviews() {
+        
+        super.layoutSubviews()
         
         let bottomSafeAreaInset = getBottomSafeAreaInset()
-		let orientation = UIApplication.shared.statusBarOrientation
-		
-		if orientation.isPortrait {
-			
-			if let languageButton = languageButton {
-				
-				playButton.frame = CGRect(x: frame.width/2 - 50, y: 10, width: 24, height: 26)
-				languageButton.frame = CGRect(x: frame.width/2 + 20, y: 10, width: 24, height: 26)
-				
-			} else {
-				
-				playButton.frame = CGRect(x: frame.width/2 - 12, y: 10, width: 24, height: 26)
-			}
-
-			volumeView.frame = CGRect(x: 44, y: bounds.height - (30 + bottomSafeAreaInset), width: bounds.width - 88, height: 22)
-			
-		} else {
-			
-			if let languageButton = languageButton {
-				
-				playButton.frame = CGRect(x: center.x, y: 7, width: 24, height: 26)
-				languageButton.frame = CGRect(x: frame.width - 45, y: 7, width: 24, height: 26)
-				
-			} else {
-				
-				playButton.frame = CGRect(x: center.x - 12, y: 7, width: 24, height: 26)
-			}
-			
-			
-			volumeView.frame = CGRect(x: 20, y: bounds.size.height - (30 + bottomSafeAreaInset), width: bounds.width/2 - 50, height: 22)
-		}
-	}
+        let orientation = UIApplication.shared.statusBarOrientation
+        
+        if orientation.isPortrait {
+            
+            if let languageButton = languageButton {
+                
+                playButton.frame = CGRect(x: frame.width/2 - 50, y: 10, width: 24, height: 26)
+                languageButton.frame = CGRect(x: frame.width/2 + 20, y: 10, width: 24, height: 26)
+                
+            } else {
+                
+                playButton.frame = CGRect(x: frame.width/2 - 12, y: 10, width: 24, height: 26)
+            }
+            
+            volumeView.frame = CGRect(x: 44, y: bounds.height - (30 + bottomSafeAreaInset), width: bounds.width - 88, height: 22)
+            
+        } else {
+            
+            if let languageButton = languageButton {
+                
+                playButton.frame = CGRect(x: center.x, y: 7, width: 24, height: 26)
+                languageButton.frame = CGRect(x: frame.width - 45, y: 7, width: 24, height: 26)
+                
+            } else {
+                
+                playButton.frame = CGRect(x: center.x - 12, y: 7, width: 24, height: 26)
+            }
+            
+            
+            volumeView.frame = CGRect(x: 20, y: bounds.size.height - (30 + bottomSafeAreaInset), width: bounds.width/2 - 50, height: 22)
+        }
+    }
 }


### PR DESCRIPTION
On newer devices, such as the iPhone X, the safe area insets were not taken into account when laying out views, resulting in the volume controls being unreachable (as they'd sit in the same region as the home bar).

Now, the safe area inset is taken into account, and on the newer devices the volume control is now usable!