### PR TITLE
Fixes language selection where no exact match found

### DIFF
--- a/ThunderCloud/StormLanguageController.swift
+++ b/ThunderCloud/StormLanguageController.swift
@@ -407,7 +407,7 @@ public class StormLanguageController: NSObject {
     /// - Returns: An array of TSCLanguage objects
     public func availableStormLanguages() -> [Language]? {
         
-        let languageFiles = ContentController.shared.fileNames(inDirectory: "languages")
+        let languageFiles = ContentController.shared.fileNames(inDirectory: "languages")?.sorted()
         
         return languageFiles?.compactMap({ (fileName: String) -> Language? in
 			


### PR DESCRIPTION
Fixes issue where a random language would be selected if no exact match could be found caused by `fileNames(inDirectory:)` returning a random order for files.

This caused issues in the case where there was no exact match between the user's preferred languages and a minor/major pack combination!